### PR TITLE
feat: default to off in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The library is used to simulate an OAuth server locally. All calls to the Social
 
 **:warning: WARNING: install this package only as dev dependency due to security reasons.**
 
+By default, the package is disabled in production (when `APP_ENV=production`). You can explicity control if the interceptor is enabled by setting `SOCIALITE_LOCAL_ENABLED=true` (or `false`) in your environment file.
+
 ## Usage
 Just use socialite as usual:
 ```php

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "laravel socialite",
     "oauth",
     "socialite",
-    "local develop"
+    "local develop",
+    "dev"
   ],
   "license": "MIT",
   "authors": [

--- a/config/socialite-local.php
+++ b/config/socialite-local.php
@@ -1,6 +1,6 @@
 <?php
 return [
     // Default to off in production; enable explicitly with SOCIALITE_LOCAL_ENABLED=true
-    'enabled' => env('SOCIALITE_LOCAL_ENABLED', env('APP_ENV', 'production') !== 'production'),
+    'enabled' => env('SOCIALITE_LOCAL_ENABLED', true),
     'use_original_mapper' => env('SOCIALITE_LOCAL_USE_ORIGINAL_MAPPER', true),
 ];

--- a/config/socialite-local.php
+++ b/config/socialite-local.php
@@ -1,5 +1,6 @@
 <?php
 return [
-    'enabled' => env('SOCIALITE_LOCAL_ENABLED', true),
+    // Default to off in production; enable explicitly with SOCIALITE_LOCAL_ENABLED=true
+    'enabled' => env('SOCIALITE_LOCAL_ENABLED', env('APP_ENV', 'production') !== 'production'),
     'use_original_mapper' => env('SOCIALITE_LOCAL_USE_ORIGINAL_MAPPER', true),
 ];

--- a/src/Interceptor.php
+++ b/src/Interceptor.php
@@ -22,7 +22,7 @@ class Interceptor
 
     public function changeProvider(Provider $originalProvider, $driver)
     {
-        if($this->config['enabled'] !== true){
+        if (app()->environment('production') || $this->config['enabled'] !== true){
             return $originalProvider;
         }
         //TODO work with oauth1 providers


### PR DESCRIPTION
I've been caught out a few times by relying on the `-d` behaviour of composer. There are cases where the `vendor` ends up in production with its dev dependencies. 

While not ideal, I've seen cases where the pipeline is doing a full `composer install` (inc. dev) to execute e2e tests (which are dev deps), but then the app is rsync'ed to the its production server(s). 

Long story short, I don't think its ideal to rely only on dependency management to make sure the interceptor isn't running in product. 

This change will default to off in production, unless explicity overwritten with the existing `SOCIALITE_LOCAL_ENABLED` flag.

Open to thoughts though 